### PR TITLE
Simplify math game for teacher-focused prompts

### DIFF
--- a/MathGameProject/app.js
+++ b/MathGameProject/app.js
@@ -66,153 +66,101 @@ const formatList = items => items.map(item => `<li>${item}</li>`).join('');
 
 const generatorLibrary = [
   {
-    id: 'subscription-stack',
-    title: 'Subscription Stack Budget',
+    id: 'pull-list-discount',
+    title: 'Pull-Box Discount Check',
     context: 'comics',
     skill: 'percents',
     standards: ['CCSS.MATH.CONTENT.7.RP.A.3', 'CCSS.MATH.CONTENT.7.EE.B.3'],
-    description: 'Percent decrease (subscription discount) and percent increase (sales tax) in a single purchase.',
-    generate: ({ audience }) => {
+    generate: () => {
       const subtotal = choose([48, 56, 64, 72, 84]);
       const discountRate = 0.2;
       const taxRate = 0.085;
-      const discounted = subtotal * (1 - discountRate);
-      const total = roundTo(discounted * (1 + taxRate));
-      const savings = roundTo(subtotal - discounted);
+      const discounted = roundTo(subtotal * (1 - discountRate));
       const taxAmount = roundTo(discounted * taxRate);
-
-      const prompt =
-        audience === 'student'
-          ? `Your long box pull-list at I Like Comics rings up to ${toCurrency(subtotal)}. Your subscription knocks off 20%, then Washington's 8.5% sales tax hits the new total. What do you actually pay at the register?`
-          : `Andrew's curated subscription stack has a shelf price of ${toCurrency(subtotal)}. After the automatic 20% pull-box discount and Washington's 8.5% sales tax, what total should the receipt show?`;
-
-      const solutionSteps = [
-        `Discounted subtotal = ${toCurrency(subtotal)} × (1 - 0.20) = ${toCurrency(discounted)}.`,
-        `Sales tax = ${toCurrency(discounted)} × 0.085 = ${toCurrency(taxAmount)}.`,
-        `Total due = ${toCurrency(discounted)} + ${toCurrency(taxAmount)} = ${toCurrency(total)}.`
-      ];
-
-      const extension =
-        audience === 'student'
-          ? 'If the shop offered a holiday 25% discount instead, how much more would you save?'
-          : 'Ask students to compare with a hypothetical 25% discount or a different state tax rate to highlight proportional reasoning.';
+      const total = roundTo(discounted + taxAmount);
 
       return {
-        title: 'Stack Savings vs. Tax',
-        contextLine: 'Comic shop finance • Pull-box discount and register math',
-        prompt,
-        solution: `${formatList(solutionSteps)}`,
-        finalAnswer: `Andrew pays ${toCurrency(total)} after discount and tax.`,
-        whyItMatters:
-          'Comic retailers rely on accurate point-of-sale math to keep subscription customers happy and inventory profitable.',
-        extension
+        title: 'Pull-Box Discount Check',
+        contextLine: 'Comic shop math • Discount plus sales tax',
+        prompt: `Read aloud: "Andrew's pull list at Brightstar Comics costs ${toCurrency(subtotal)} before discounts. The shop takes 20% off for his pull box and then adds 8.5% sales tax. What should the final receipt total be?"`,
+        solutionSteps: [
+          `Discount: ${toCurrency(subtotal)} × 0.20 = ${toCurrency(roundTo(subtotal * discountRate))}.`,
+          `Sale price: ${toCurrency(subtotal)} - discount = ${toCurrency(discounted)}.`,
+          `Tax: ${toCurrency(discounted)} × 0.085 = ${toCurrency(taxAmount)}.`,
+          `Total: ${toCurrency(discounted)} + ${toCurrency(taxAmount)} = ${toCurrency(total)}.`
+        ],
+        finalAnswer: `${toCurrency(total)} due at checkout.`,
+        whyItMatters: 'Teachers can connect percent decrease and increase in one tidy comic book scenario.',
+        extension: 'Change the tax rate to your city or adjust the discount to 15% and compare totals.'
       };
     }
   },
   {
-    id: 'reimbursement-runs',
-    title: 'Variant Reimbursement Deal',
+    id: 'variant-split',
+    title: 'Variant Team-Up Split',
     context: 'comics',
     skill: 'percents',
     standards: ['CCSS.MATH.CONTENT.7.RP.A.3'],
-    description: 'Percent of a purchase reimbursed after buying limited variants.',
-    generate: ({ audience }) => {
-      const spend = choose([24, 28, 36, 44, 52, 60]);
+    generate: () => {
+      const spend = choose([28, 36, 44, 52, 60]);
       const paybackRate = 0.25;
       const payback = roundTo(spend * paybackRate);
       const netCost = roundTo(spend - payback);
-      const prompt =
-        audience === 'student'
-          ? `You and your dad split horror variant issues. You spend ${toCurrency(spend)} this week, and he pays you back 25%. How much do you get back, and what is your final cost?`
-          : `Andrew is collecting horror variant covers. If he spends ${toCurrency(spend)} and his dad reimburses 25%, determine the reimbursement amount and Andrew's remaining cost.`;
-
-      const solutionSteps = [
-        `Reimbursement = ${toCurrency(spend)} × 0.25 = ${toCurrency(payback)}.`,
-        `Andrew's share = ${toCurrency(spend)} - ${toCurrency(payback)} = ${toCurrency(netCost)}.`
-      ];
-
-      const extension =
-        audience === 'student'
-          ? 'If the next limited cover costs ${toCurrency(spend + 8)} and he still pays back 25%, how much will you owe?'
-          : 'Invite students to create an equation representing Andrew’s net cost: \(c = 0.75s\).';
 
       return {
-        title: 'Reimbursed Variant Haul',
-        contextLine: 'Comic collecting • Shared spending agreement',
-        prompt,
-        solution: `${formatList(solutionSteps)}`,
-        finalAnswer: `Dad reimburses ${toCurrency(payback)}, so Andrew’s cost is ${toCurrency(netCost)}.`,
-        whyItMatters:
-          'Negotiating collector partnerships requires fluency with percentages to keep every issue and friendship balanced.',
-        extension
+        title: 'Variant Team-Up Split',
+        contextLine: 'Collecting strategy • Sharing a limited cover haul',
+        prompt: `Read aloud: "Andrew and his cousin split a stack of limited variant issues that cost ${toCurrency(spend)}. The cousin covers 25% of the bill later. How much money should Andrew get back, and what is his final cost?"`,
+        solutionSteps: [
+          `Cousin share: ${toCurrency(spend)} × 0.25 = ${toCurrency(payback)}.`,
+          `Andrew pays after payback: ${toCurrency(spend)} - ${toCurrency(payback)} = ${toCurrency(netCost)}.`
+        ],
+        finalAnswer: `Andrew gets ${toCurrency(payback)} back and keeps ${toCurrency(netCost)} as his cost.`,
+        whyItMatters: 'Shows percent of a total and reinforces how collectors plan shared buys.',
+        extension: 'Have students model the net cost with an equation such as c = 0.75s and plug in a new stack price.'
       };
     }
   },
   {
     id: 'graphic-binders',
-    title: 'Graphic Novel Binders',
+    title: 'Trade Binder Count',
     context: 'comics',
     skill: 'numbers',
     standards: ['CCSS.MATH.CONTENT.7.NS.A.3'],
-    description: 'Division with remainder to convert single issues into collected editions.',
-    generate: ({ audience }) => {
+    generate: () => {
       const issues = ensureNotMultiple(20, 38, [6]);
       const perVolume = 6;
       const fullVolumes = Math.floor(issues / perVolume);
       const leftovers = issues % perVolume;
-      const prompt =
-        audience === 'student'
-          ? `Every 6 single issues of your horror run get bound into one deluxe graphic novel. You just finished reading ${issues} issues. How many complete graphic novels can you bind, and how many single issues are left loose?`
-          : `Andrew wants to archive ${issues} single issues into collected editions, with 6 issues per bind-up. Determine the number of complete volumes and the remaining singles.`;
-
-      const solutionSteps = [
-        `${issues} ÷ 6 = ${fullVolumes} remainder ${leftovers}.`,
-        `He can bind ${fullVolumes} complete graphic novels and will have ${leftovers} single issues left.`
-      ];
-
-      const extension =
-        audience === 'student'
-          ? 'If a custom binder holds 4 graphic novels, will one binder handle the whole run? Explain.'
-          : 'Discuss interpreting remainders in context: the remainder becomes a planning decision for future purchases.';
 
       return {
-        title: 'Binding the Horror Run',
-        contextLine: 'Collection management • Turning issues into deluxe editions',
-        prompt,
-        solution: `${formatList(solutionSteps)}`,
-        finalAnswer: `${fullVolumes} graphic novels with ${leftovers} single issues leftover.`,
-        whyItMatters:
-          'Publishers schedule bind-ups by tracking issue counts; collectors do the same to plan shelves and budgets.',
-        extension
+        title: 'Trade Binder Count',
+        contextLine: 'Collection planning • Turning single issues into trades',
+        prompt: `Read aloud: "A trade binder holds 6 single issues. Andrew has ${issues} issues ready to archive. How many full trades can he build, and how many single issues will still be loose?"`,
+        solutionSteps: [
+          `${issues} ÷ 6 = ${fullVolumes} remainder ${leftovers}.`,
+          `${fullVolumes} full trades with ${leftovers} single issues left over.`
+        ],
+        finalAnswer: `${fullVolumes} complete trades and ${leftovers} singles to store separately.`,
+        whyItMatters: 'Interpreting the remainder helps Andrew plan the next binder purchase.',
+        extension: 'Ask students to plan for one more binder and decide how many more issues are needed to fill it.'
       };
     }
   },
   {
     id: 'con-budget',
-    title: 'Comic-Con Merch Matrix',
+    title: 'Convention Budget Board',
     context: 'comics',
     skill: 'equations',
     standards: ['CCSS.MATH.CONTENT.7.EE.B.3'],
-    description: 'Budget inequality using set merchandise prices at a convention.',
-    generate: ({ audience }) => {
+    generate: () => {
       const budget = 75;
       const items = [
-        { name: 'Signed slasher poster', price: 25.5 },
-        { name: 'Indie horror trade paperback', price: 18.75 },
+        { name: 'Signed hero poster', price: 24.5 },
         { name: 'Foil variant comic', price: 22.4 },
-        { name: 'FX makeup demo kit', price: 28.6 }
+        { name: 'Artist sketchbook', price: 18.75 },
+        { name: 'DIY costume toolkit', price: 28.6 }
       ];
-
-      const prompt =
-        audience === 'student'
-          ? `You have $${budget} to spend at Comic Con. Prices (tax included):
-- Signed slasher poster: ${toCurrency(items[0].price)}
-- Indie horror trade paperback: ${toCurrency(items[1].price)}
-- Foil variant comic: ${toCurrency(items[2].price)}
-- FX makeup demo kit: ${toCurrency(items[3].price)}
-
-Can you buy three items without going over budget? Which two-item combos fit best, and how much money would you have left?`
-          : `Andrew's Comic Con budget is $${budget}. With the listed tax-included prices, determine whether any three-item combinations meet the budget. Identify all two-item combinations that stay within the budget and compute the remaining balance for the best choice.`;
 
       const combos = [];
       for (let i = 0; i < items.length; i++) {
@@ -241,79 +189,53 @@ Can you buy three items without going over budget? Which two-item combos fit bes
       }
 
       const canBuyThree = cheapestThreeTotal <= budget;
-
       const sortedCombos = [...combos].sort((a, b) => b.leftover - a.leftover);
       const comboList = sortedCombos.map(
         combo => `${combo.pair}: ${toCurrency(combo.total)} (leftover ${toCurrency(combo.leftover)})`
       );
 
-      const threeItemSummary = Number.isFinite(cheapestThreeTotal)
-        ? `Most affordable three-item bundle costs ${toCurrency(cheapestThreeTotal)} ⇒ ${
-            canBuyThree ? 'within budget' : 'over budget (cannot buy three).'
-          }`
-        : 'No three-item combinations available to evaluate.';
-
-      const solutionSteps = [
-        threeItemSummary,
-        `Two-item combos within budget:${comboList.length ? '' : ' none.'}`,
-        ...comboList.map(text => text)
-      ];
-
-      const extension =
-        audience === 'student'
-          ? 'Design your own three-item wishlist with at least one filmmaking supply. Keep it under $75 and show the math.'
-          : 'Model the situation with an inequality such as \(22.4 + 18.75 + x \leq 75\) and have students solve for the remaining spending power.';
-
       return {
-        title: 'Comic-Con Merch Matrix',
-        contextLine: 'Convention strategy • Budgeting collectibles and gear',
-        prompt,
-        solution: `${formatList(solutionSteps)}`,
+        title: 'Convention Budget Board',
+        contextLine: 'Budget planning • Spending under a set cap',
+        prompt: `Read aloud: "Andrew brings $${budget} to a convention. Prices already include tax. Which two-item bundle stays under budget with the most money left, and is any three-item bundle possible?"`,
+        solutionSteps: [
+          `Cheapest three-item bundle costs ${Number.isFinite(cheapestThreeTotal) ? toCurrency(cheapestThreeTotal) : 'N/A'} ⇒ ${
+            canBuyThree ? 'within budget' : 'over budget'
+          }.`,
+          comboList.length ? 'Two-item bundles within budget:' : 'No two-item bundle fits the budget.',
+          ...comboList
+        ],
         finalAnswer: `${
-          canBuyThree ? 'Andrew can stretch to three items.' : 'No three-item combo fits the budget.'
+          canBuyThree ? 'A three-item combo fits.' : 'No three-item combo fits the cap.'
         } Best two-item choice leaves ${toCurrency(sortedCombos[0]?.leftover ?? 0)} remaining.`,
-        whyItMatters:
-          'Conventions mix impulse buys with production tools—budget planning keeps indie creators funded.',
-        extension
+        whyItMatters: 'Teachers can model inequalities and reasoning about combinations without heavy text.',
+        extension: 'Invite students to suggest a new item and test how it changes the best bundle.'
       };
     }
   },
   {
     id: 'storyboard-progress',
-    title: 'Storyboard Sprint',
+    title: 'Storyboard Progress Check',
     context: 'film',
     skill: 'percents',
     standards: ['CCSS.MATH.CONTENT.7.RP.A.3'],
-    description: 'Percent completion and remaining work for a production timeline.',
-    generate: ({ audience }) => {
+    generate: () => {
       const totalShots = choose([48, 52, 60]);
       const completed = choose([18, 20, 24]);
       const percentComplete = roundTo((completed / totalShots) * 100, 1);
       const shotsLeft = totalShots - completed;
-      const prompt =
-        audience === 'student'
-          ? `Your horror short has ${totalShots} planned camera setups. You've storyboarded ${completed} of them this week. What percent of the storyboard is complete, and how many setups still need drawings before you can start filming?`
-          : `Andrew mapped ${completed} of ${totalShots} planned shots for his horror short. Calculate the percent of storyboard completion and the remaining number of shots.`;
-
-      const solutionSteps = [
-        `Percent complete = (${completed} ÷ ${totalShots}) × 100 = ${percentComplete}%.`,
-        `Shots remaining = ${totalShots} - ${completed} = ${shotsLeft}.`
-      ];
-
-      const extension =
-        audience === 'student'
-          ? 'If you can finish 6 storyboards per night, how many nights until you wrap the planning phase?'
-          : 'Have students create a double number line comparing shots completed to total shots to visualize progress.';
 
       return {
-        title: 'Storyboard Sprint',
-        contextLine: 'Film pre-production • Tracking storyboard progress',
-        prompt,
-        solution: `${formatList(solutionSteps)}`,
-        finalAnswer: `${percentComplete}% complete with ${shotsLeft} shots left to draw.`,
-        whyItMatters:
-          'Directors use percent-complete metrics to keep pre-production on schedule before renting gear or hiring crew.',
-        extension
+        title: 'Storyboard Progress Check',
+        contextLine: 'Film club planning • Tracking percent complete',
+        prompt: `Read aloud: "The film club mapped ${completed} of ${totalShots} planned shots for their mini-movie. What percent is complete, and how many shots remain?"`,
+        solutionSteps: [
+          `Percent complete = (${completed} ÷ ${totalShots}) × 100 = ${percentComplete}%.`,
+          `Shots left = ${totalShots} - ${completed} = ${shotsLeft}.`
+        ],
+        finalAnswer: `${percentComplete}% done with ${shotsLeft} shots still to storyboard.`,
+        whyItMatters: 'Connects percent progress to a school film project Andrew knows from AV club.',
+        extension: 'Ask how many days it will take if the team can finish 6 shots per work session.'
       };
     }
   },
@@ -323,137 +245,96 @@ Can you buy three items without going over budget? Which two-item combos fit bes
     context: 'film',
     skill: 'percents',
     standards: ['CCSS.MATH.CONTENT.7.RP.A.3'],
-    description: 'Ratios determine cost sharing for rental equipment.',
-    generate: ({ audience }) => {
+    generate: () => {
       const weekendRate = 420;
       const ratio = [2, 1, 1];
       const totalParts = ratio.reduce((a, b) => a + b, 0);
-      const andrewShare = roundTo((ratio[0] / totalParts) * weekendRate);
-      const othersShare = weekendRate - andrewShare;
-
-      const prompt =
-        audience === 'student'
-          ? `You split a $${weekendRate} weekend rental for a lighting kit with two other teen directors. Because you booked extra night shoots, you cover a double share compared to each friend. How much do you pay?`
-          : `Three student directors split a $${weekendRate} lighting rental in a 2:1:1 ratio (Andrew takes the 2 share). Determine Andrew's cost and how much the others cover together.`;
-
-      const solutionSteps = [
-        `Total ratio parts = 2 + 1 + 1 = ${totalParts}.`,
-        `Each part costs ${toCurrency(weekendRate / totalParts)}.`,
-        `Andrew pays 2 parts ⇒ ${toCurrency(andrewShare)}. The others split the remaining ${toCurrency(othersShare)}.`
-      ];
-
-      const extension =
-        audience === 'student'
-          ? 'What if four friends split the same kit equally? Compare your cost.'
-          : 'Connect to double number lines showing ratio of cost to usage hours to reinforce proportional reasoning.';
+      const partCost = roundTo(weekendRate / totalParts);
+      const andrewShare = roundTo(partCost * ratio[0]);
+      const othersShare = roundTo(weekendRate - andrewShare);
 
       return {
         title: 'Lighting Kit Cost Share',
-        contextLine: 'Production budgeting • Splitting rental equipment',
-        prompt,
-        solution: `${formatList(solutionSteps)}`,
-        finalAnswer: `Andrew covers ${toCurrency(andrewShare)} while friends share ${toCurrency(othersShare)}.`,
-        whyItMatters:
-          'Indie crews divide rental costs by usage; ratios keep budgets fair when screen time varies.',
-        extension
+        contextLine: 'Production budgeting • Splitting rental fees',
+        prompt: `Read aloud: "Three film club leads split a $${weekendRate} lighting rental in a 2:1:1 ratio because Andrew booked extra shooting time. How much does Andrew pay, and how much do the others cover together?"`,
+        solutionSteps: [
+          `Total parts = 2 + 1 + 1 = ${totalParts}.`,
+          `Each part costs ${toCurrency(partCost)}.`,
+          `Andrew pays 2 parts = ${toCurrency(andrewShare)}; friends cover the remaining ${toCurrency(othersShare)}.`
+        ],
+        finalAnswer: `Andrew pays ${toCurrency(andrewShare)}; the team covers ${toCurrency(othersShare)} together.`,
+        whyItMatters: 'Simple ratio split mirrors how clubs share gear rentals.',
+        extension: 'Change the ratio to 3:1:1 if Andrew adds another night and compare the cost shift.'
       };
     }
   },
   {
     id: 'scene-equation',
-    title: 'Editing Equation',
+    title: 'Scene Count Equation',
     context: 'film',
     skill: 'equations',
     standards: ['CCSS.MATH.CONTENT.7.EE.B.4'],
-    description: 'Linear equation representing shot counts and total runtime.',
-    generate: ({ audience }) => {
+    generate: () => {
       const runtimeSeconds = choose([360, 390]);
       const specialSceneLength = choose([48, 54]);
       const baseSceneLength = choose([30, 36]);
-      const prompt =
-        audience === 'student'
-          ? `Your horror short must be ${runtimeSeconds / 60} minutes long (${runtimeSeconds} seconds total). Most scenes run about ${baseSceneLength} seconds, but your finale chase takes ${specialSceneLength} seconds. How many standard scenes can you include along with the finale to hit the exact runtime?`
-          : `Andrew is editing a ${runtimeSeconds / 60}-minute short (${runtimeSeconds} seconds). He plans one ${specialSceneLength}-second climax scene and the rest at ${baseSceneLength} seconds each. Set up and solve an equation for the number of regular scenes.`;
-
       const regularScenes = Math.floor((runtimeSeconds - specialSceneLength) / baseSceneLength);
-      const solutionSteps = [
-        `Let \(x\) = number of regular scenes.`,
-        `Equation: ${baseSceneLength}x + ${specialSceneLength} = ${runtimeSeconds}.`,
-        `${baseSceneLength}x = ${runtimeSeconds - specialSceneLength}.`,
-        `x = ${runtimeSeconds - specialSceneLength} ÷ ${baseSceneLength} = ${regularScenes}.`
-      ];
-
-      const extension =
-        audience === 'student'
-          ? 'If you add a 12-second jump-scare insert, adjust your equation. Does a new solution still use whole scenes?'
-          : 'Discuss what to do with remainders—does the pacing allow for a shorter transition scene?';
 
       return {
-        title: 'Editing to Exact Runtime',
-        contextLine: 'Post-production math • Balancing runtime with scene lengths',
-        prompt,
-        solution: `${formatList(solutionSteps)}`,
-        finalAnswer: `Andrew can include ${regularScenes} regular scenes plus the finale to hit the exact runtime.`,
-        whyItMatters:
-          'Editors juggle scene lengths to meet festival runtime limits without cutting story beats.',
-        extension
+        title: 'Scene Count Equation',
+        contextLine: 'Editing math • Building a clean runtime',
+        prompt: `Read aloud: "A short film must run ${runtimeSeconds / 60} minutes (${runtimeSeconds} seconds). One hero team-up finale lasts ${specialSceneLength} seconds. All other scenes are ${baseSceneLength} seconds each. Set up and solve an equation to find how many regular scenes fit."`,
+        solutionSteps: [
+          `Let x = regular scenes.`,
+          `Equation: ${baseSceneLength}x + ${specialSceneLength} = ${runtimeSeconds}.`,
+          `${baseSceneLength}x = ${runtimeSeconds - specialSceneLength}.`,
+          `x = ${runtimeSeconds - specialSceneLength} ÷ ${baseSceneLength} = ${regularScenes}.`
+        ],
+        finalAnswer: `${regularScenes} regular scenes plus the finale hit the runtime target.`,
+        whyItMatters: 'Gives context for solving one-step equations with a known total.',
+        extension: 'Ask what happens if one more 12-second transition is added to the plan.'
       };
     }
   },
   {
     id: 'retake-data',
-    title: 'FX Retake Analyzer',
+    title: 'Reshoot Tracker Stats',
     context: 'film',
     skill: 'stats',
     standards: ['CCSS.MATH.CONTENT.7.SP.B.4'],
-    description: 'Compute mean retakes per scene and interpret the data.',
-    generate: ({ audience }) => {
+    generate: () => {
       const retakes = choose([
-        [3, 4, 2, 5, 3],
-        [2, 6, 4, 3, 5],
-        [1, 3, 4, 6, 2]
+        [2, 4, 3, 5, 3],
+        [1, 5, 4, 3, 2],
+        [2, 3, 4, 6, 3]
       ]);
-      const weekLabels = ['Scene 1', 'Scene 2', 'Scene 3', 'Scene 4', 'Scene 5'];
+      const labels = ['Scene 1', 'Scene 2', 'Scene 3', 'Scene 4', 'Scene 5'];
       const sum = retakes.reduce((a, b) => a + b, 0);
       const mean = roundTo(sum / retakes.length, 2);
       const mostRetakes = Math.max(...retakes);
       const hardestSceneIndex = retakes.indexOf(mostRetakes);
 
-      const prompt =
-        audience === 'student'
-          ? `During FX filming you tracked retakes for five scenes: ${retakes.join(', ')}. What is the average number of retakes per scene, and which scene chewed up the most time?`
-          : `Andrew logged retake counts for five practical FX scenes (${retakes.join(', ')}). Compute the mean retakes and identify the scene needing the most coaching.`;
-
-      const solutionSteps = [
-        `Mean = (${retakes.join(' + ')}) ÷ 5 = ${mean} retakes.`,
-        `Maximum retakes = ${mostRetakes} on ${weekLabels[hardestSceneIndex]}.`
-      ];
-
-      const extension =
-        audience === 'student'
-          ? 'Plan how many extra takes to budget if you expect the next night to run 1 retake above the mean per scene.'
-          : 'Invite students to graph the data and discuss variability—should Andrew schedule an extra rehearsal for the toughest scene?';
-
       return {
-        title: 'FX Retake Analyzer',
-        contextLine: 'On-set data • Using averages to schedule reshoots',
-        prompt,
-        solution: `${formatList(solutionSteps)}`,
-        finalAnswer: `Average of ${mean} retakes; ${weekLabels[hardestSceneIndex]} needs the most attention with ${mostRetakes} retakes.`,
-        whyItMatters:
-          'Keeping track of retakes helps crews predict overtime costs and coach actors through complex practical effects.',
-        extension
+        title: 'Reshoot Tracker Stats',
+        contextLine: 'On-set data • Reading the average number of retakes',
+        prompt: `Read aloud: "Retake counts for five scenes came out as ${retakes.join(', ')}. What is the average number of retakes per scene, and which scene needs the most review?"`,
+        solutionSteps: [
+          `Mean = (${retakes.join(' + ')}) ÷ 5 = ${mean}.`,
+          `Most retakes: ${mostRetakes} on ${labels[hardestSceneIndex]}.`
+        ],
+        finalAnswer: `Average of ${mean} retakes; ${labels[hardestSceneIndex]} needs the most support.`,
+        whyItMatters: 'Supports talk about mean and variability with a familiar film-club log.',
+        extension: 'Have students graph the data and suggest how many practice runs to schedule next time.'
       };
     }
   },
   {
     id: 'variant-probability',
-    title: 'Mystery Variant Probability',
+    title: 'Mystery Variant Odds',
     context: 'comics',
     skill: 'stats',
     standards: ['CCSS.MATH.CONTENT.7.SP.C.6'],
-    description: 'Probability of pulling special variant covers from blind bags.',
-    generate: ({ audience }) => {
+    generate: () => {
       const totalBags = 40;
       const glowVariants = choose([6, 8, 10]);
       const sketchVariants = choose([4, 5, 6]);
@@ -461,117 +342,50 @@ Can you buy three items without going over budget? Which two-item combos fit bes
       const glowProbability = roundTo(glowVariants / totalBags, 2);
       const sketchProbability = roundTo(sketchVariants / totalBags, 2);
 
-      const prompt =
-        audience === 'student'
-          ? `A booth sells 40 sealed mystery horror-comic variants: ${glowVariants} glow-in-the-dark, ${sketchVariants} artist sketch, and the rest regular covers. If you buy one bag, what is the probability of landing a glow variant? What about a sketch cover?`
-          : `From a 40-bag blind pull (with ${glowVariants} glow variants and ${sketchVariants} sketch variants), determine the probability of each special cover to help Andrew decide if the bundle is worth it.`;
-
-      const solutionSteps = [
-        `Glow probability = ${glowVariants} ÷ 40 = ${glowProbability}.`,
-        `Sketch probability = ${sketchVariants} ÷ 40 = ${sketchProbability}.`,
-        `Regular covers = ${regular} bags.`
-      ];
-
-      const extension =
-        audience === 'student'
-          ? 'If you grab two bags without replacement, estimate the chance you snag both special covers.'
-          : 'Have students simulate pulls with counters to compare experimental probability to the theoretical values.';
-
       return {
-        title: 'Mystery Variant Probability',
-        contextLine: 'Collectible strategy • Predicting blind-bag pulls',
-        prompt,
-        solution: `${formatList(solutionSteps)}`,
-        finalAnswer: `P(glow) = ${glowProbability}, P(sketch) = ${sketchProbability}.`,
-        whyItMatters:
-          'Knowing the odds keeps collectors from overspending on mystery bundles and informs secondary market pricing.',
-        extension
+        title: 'Mystery Variant Odds',
+        contextLine: 'Probability • Blind-bag cover reveal',
+        prompt: `Read aloud: "A blind-bag comic box holds 40 issues: ${glowVariants} glow variants, ${sketchVariants} sketch variants, and the rest regular covers. What is the probability of pulling each special cover on one draw?"`,
+        solutionSteps: [
+          `P(glow) = ${glowVariants} ÷ 40 = ${glowProbability}.`,
+          `P(sketch) = ${sketchVariants} ÷ 40 = ${sketchProbability}.`,
+          `Regular covers = ${regular} bags.`
+        ],
+        finalAnswer: `Glow: ${glowProbability}; Sketch: ${sketchProbability}.`,
+        whyItMatters: 'Highlights theoretical probability with terms Andrew hears at the comic shop.',
+        extension: 'Invite students to simulate two draws with counters and compare to the predicted odds.'
       };
     }
   },
   {
-    id: 'sound-mix-inequality',
-    title: 'Sound Mix Time Crunch',
-    context: 'film',
-    skill: 'equations',
-    standards: ['CCSS.MATH.CONTENT.7.EE.B.4'],
-    description: 'Inequality to budget time for post-production tasks.',
-    generate: ({ audience }) => {
-      const totalHours = 12;
-      const perSceneTime = 1.5;
-      const setupTime = 2;
-      const prompt =
-        audience === 'student'
-          ? `You booked ${totalHours} hours in the studio to mix sound for your horror short. Setup takes ${setupTime} hours total, and each scene needs about ${perSceneTime} hours of mixing. Write and solve an inequality to find the maximum number of scenes you can polish.`
-          : `Andrew has ${totalHours} studio hours, with ${setupTime} hours reserved for calibration. Each scene’s mix takes ${perSceneTime} hours. Model with an inequality and determine how many scenes fit.`;
-
-      const hoursRemaining = totalHours - setupTime;
-      const maxScenes = Math.floor(hoursRemaining / perSceneTime);
-      const solutionSteps = [
-        `Let \(s\) = number of scenes. Inequality: ${perSceneTime}s + ${setupTime} \leq ${totalHours}.`,
-        `${perSceneTime}s \leq ${totalHours - setupTime}.`,
-        `s \leq ${(hoursRemaining / perSceneTime).toFixed(2)} ⇒ maximum whole scenes = ${maxScenes}.`
-      ];
-
-      const extension =
-        audience === 'student'
-          ? 'If one scene needs an extra 0.5 hours for a creature sound pass, how does that change your plan?'
-          : 'Discuss why only whole scenes make sense and how to schedule B-roll or ADR if time remains.';
-
-      return {
-        title: 'Sound Mix Time Crunch',
-        contextLine: 'Post-production scheduling • Studio time inequality',
-        prompt,
-        solution: `${formatList(solutionSteps)}`,
-        finalAnswer: `Andrew can fully mix ${maxScenes} scenes during the booking.`,
-        whyItMatters:
-          'Time budgeting keeps indie productions from paying overtime at studios.',
-        extension
-      };
-    }
-  },
-  {
-    id: 'colorist-ratio',
-    title: 'Colorist Collaboration Ratio',
+    id: 'colorist-collab',
+    title: 'Coloring Sprint Ratio',
     context: 'comics',
     skill: 'numbers',
-    standards: ['CCSS.MATH.CONTENT.7.NS.A.2', 'CCSS.MATH.CONTENT.7.RP.A.3'],
-    description: 'Ratio table converting page quotas into daily goals.',
-    generate: ({ audience }) => {
-      const totalPages = choose([96, 108, 120]);
+    standards: ['CCSS.MATH.CONTENT.7.RP.A.3'],
+    generate: () => {
+      const totalPages = choose([48, 60, 72]);
       const days = choose([12, 15]);
-      const dailyGoal = totalPages / days;
-      const prompt =
-        audience === 'student'
-          ? `You and a colorist friend are finishing a ${totalPages}-page horror anthology in ${days} days for a convention launch. If you split the work evenly each day, how many pages should each of you color daily?`
-          : `Andrew and his collaborator must finish ${totalPages} pages of coloring in ${days} days. Determine the shared daily page target per artist.`;
-
-      const solutionSteps = [
-        `Pages per day together = ${totalPages} ÷ ${days} = ${roundTo(dailyGoal, 2)} pages.`,
-        `Per artist (split evenly) = ${roundTo(dailyGoal / 2, 2)} pages per day.`
-      ];
-
-      const extension =
-        audience === 'student'
-          ? 'If you sprinted and finished 4 extra pages early, how would you adjust the remaining daily goal?'
-          : 'Have students build a ratio table showing days vs. pages completed to visualize steady rates.';
+      const pagesPerDayTogether = roundTo(totalPages / days, 2);
+      const perArtist = roundTo(pagesPerDayTogether / 2, 2);
 
       return {
-        title: 'Colorist Collaboration Ratio',
-        contextLine: 'Production schedule • Meeting anthology deadlines',
-        prompt,
-        solution: `${formatList(solutionSteps)}`,
-        finalAnswer: `Team goal ${roundTo(dailyGoal, 2)} pages per day; each artist handles ${roundTo(dailyGoal / 2, 2)} pages.`,
-        whyItMatters:
-          'Publishing deadlines depend on predictable daily output for art teams.',
-        extension
+        title: 'Coloring Sprint Ratio',
+        contextLine: 'Production schedule • Splitting daily work evenly',
+        prompt: `Read aloud: "Andrew and a friend are coloring a ${totalPages}-page comic in ${days} days. They split the pages evenly each day. How many pages should they finish together per day, and how many pages is that for each artist?"`,
+        solutionSteps: [
+          `Pages per day together = ${totalPages} ÷ ${days} = ${pagesPerDayTogether}.`,
+          `Per artist = ${pagesPerDayTogether} ÷ 2 = ${perArtist}.`
+        ],
+        finalAnswer: `Team goal ${pagesPerDayTogether} pages daily; each artist handles ${perArtist} pages.`,
+        whyItMatters: 'Reinforces equal sharing and rate reasoning using comic art workflow.',
+        extension: 'Ask what happens to the plan if one artist finishes 4 bonus pages on day one.'
       };
     }
   }
 ];
 
 const elements = {
-  audience: document.getElementById('audience'),
   context: document.getElementById('context'),
   skill: document.getElementById('skill'),
   generate: document.getElementById('generate'),
@@ -600,7 +414,6 @@ const renderStandardsReference = () => {
 };
 
 const renderProblem = () => {
-  const mode = elements.audience.value;
   const contextFilter = elements.context.value;
   const skillFilter = elements.skill.value;
 
@@ -612,7 +425,7 @@ const renderProblem = () => {
 
   if (!filtered.length) {
     elements.problemTitle.textContent = 'No generator found';
-    elements.problemContext.textContent = 'Try widening your filters to see more math/story combos.';
+    elements.problemContext.textContent = 'Try widening your filters to see more math-story combos.';
     elements.problemText.textContent = '';
     elements.standards.innerHTML = '';
     elements.solutionBox.innerHTML = '';
@@ -621,7 +434,7 @@ const renderProblem = () => {
   }
 
   const selection = choose(filtered);
-  const problem = selection.generate({ audience: mode });
+  const problem = selection.generate();
 
   elements.problemTitle.textContent = problem.title;
   elements.problemContext.textContent = problem.contextLine;
@@ -630,32 +443,24 @@ const renderProblem = () => {
     .map(code => `<span class="standard-tag">${code.replace('CCSS.MATH.CONTENT.', '')}</span>`)
     .join('');
 
-  const modeHeading = mode === 'teacher' ? 'Solution Path & Answer Key' : 'How to Solve';
-  const whyHeading = mode === 'teacher' ? 'Industry Connection' : 'Why this matters IRL';
-
   elements.solutionBox.innerHTML = `
-    <h3>${modeHeading}</h3>
-    <ol>${problem.solution}</ol>
-    <p class="final-answer"><strong>Final answer:</strong> ${problem.finalAnswer}</p>
-    <p class="why">${whyHeading}: ${problem.whyItMatters}</p>
+    <h3>Solution Path</h3>
+    <ol>${formatList(problem.solutionSteps)}</ol>
+    <p class="final-answer"><strong>Answer:</strong> ${problem.finalAnswer}</p>
+    <p class="why"><strong>Teacher note:</strong> ${problem.whyItMatters}</p>
   `;
 
   elements.extensionBox.innerHTML = `
-    <h3>Extend the Story</h3>
+    <h3>Extension Idea</h3>
     <p>${problem.extension}</p>
   `;
 
-  elements.researchCard.querySelector('h3').textContent =
-    mode === 'teacher' ? 'Teacher Toolkit' : 'Player Boosts';
-  elements.researchCard.querySelector('p').textContent =
-    mode === 'teacher'
-      ? 'Each challenge comes with authentic production context, CCSS tags, and ready-to-use solution moves.'
-      : 'Unlock behind-the-scenes facts, bonus missions, and tips to level up your own comic or film project while you solve.';
+  elements.researchCard.querySelector('h3').textContent = 'Quick Teacher Notes';
+  elements.researchCard.querySelector('p').textContent = 'Each card gives a prompt, answer path, and a short extension.';
 };
 
 elements.generate.addEventListener('click', renderProblem);
 
-elements.audience.addEventListener('change', renderProblem);
 elements.context.addEventListener('change', renderProblem);
 elements.skill.addEventListener('change', renderProblem);
 

--- a/MathGameProject/index.html
+++ b/MathGameProject/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Comics & Film Math Studio</title>
+  <title>Teacher Comics Math Prompter</title>
   <link rel="stylesheet" href="styles.css" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -11,32 +11,18 @@
 </head>
 <body>
   <header class="hero">
-    <div class="hero__text">
-      <h1>Comics &amp; Film Math Studio</h1>
-      <p class="tagline">Generate standards-aligned math challenges that speak Andrew's language.</p>
-      <p class="subtagline">Pick your focus, connect to real production and comic book decisions, and get a ready-to-teach prompt with solutions.</p>
-    </div>
-    <div class="hero__badge">
-      <span class="badge__label">Aligned to</span>
-      <span class="badge__value">Grade 7 CCSS-M</span>
-    </div>
+    <h1>Teacher Comics Math Prompter</h1>
+    <p class="tagline">Quick CCSS-friendly story problems that match Andrew's comic know-how.</p>
   </header>
 
   <main>
     <section class="controls">
       <div class="control-group">
-        <label for="audience">Audience</label>
-        <select id="audience">
-          <option value="teacher">Teacher Planning Mode</option>
-          <option value="student">Player Mode</option>
-        </select>
-      </div>
-      <div class="control-group">
         <label for="context">Universe</label>
         <select id="context">
-          <option value="all">Comics &amp; Film</option>
+          <option value="all">Comics &amp; Film Club</option>
           <option value="comics">Comic Books</option>
-          <option value="film">Film Production</option>
+          <option value="film">Film Projects</option>
         </select>
       </div>
       <div class="control-group">
@@ -49,20 +35,20 @@
           <option value="stats">Statistics &amp; Probability (7.SP)</option>
         </select>
       </div>
-      <button id="generate" class="primary">Generate a Fresh Challenge</button>
+      <button id="generate" class="primary">Generate Example</button>
     </section>
 
     <section class="output" aria-live="polite">
       <article class="card" id="problem-card">
         <header class="card__header">
           <div>
-            <h2 id="problem-title">Pick a universe to get started</h2>
+            <h2 id="problem-title">Choose a topic to get started</h2>
             <p id="problem-context" class="card__context"></p>
           </div>
           <div class="standards" id="standard-tags"></div>
         </header>
         <div class="card__body">
-          <p id="problem-text" class="card__prompt">Use the controls above to curate a challenge.</p>
+          <p id="problem-text" class="card__prompt">Use the controls above to pull a clean prompt.</p>
         </div>
         <footer class="card__footer" id="solution-area">
           <div class="solution" id="solution-box"></div>
@@ -71,15 +57,9 @@
       </article>
 
       <aside class="card research" id="research-card">
-        <h3>Teacher Toolkit</h3>
-        <p>Each challenge includes:</p>
-        <ul>
-          <li><strong>Why it matters</strong> in comics or filmmaking.</li>
-          <li><strong>Standards map</strong> with CCSS identifiers and skill strands.</li>
-          <li><strong>Solution strategy</strong> for quick checks or answer keys.</li>
-          <li><strong>Extension prompts</strong> to keep curious students digging.</li>
-        </ul>
-        <p class="small">Research sources: CCSS Grade 7 domains 7.RP, 7.NS, 7.EE, 7.SP; industry interviews with comic shop managers and indie filmmakers; production budgeting guides.</p>
+        <h3>Quick Teacher Notes</h3>
+        <p>Each card gives a prompt, answer path, and a short extension.</p>
+        <p class="small">Anchored to CCSS Grade 7 strands: 7.RP, 7.NS, 7.EE, 7.SP.</p>
       </aside>
     </section>
 
@@ -90,7 +70,7 @@
   </main>
 
   <footer class="footer">
-    <p>Built for Andrew with authentic comic shop math and indie film production decisions.</p>
+    <p>Built for Andrew's teacher team. Comic inside jokes stay; wording stays clear.</p>
   </footer>
 
   <script src="app.js"></script>

--- a/MathGameProject/styles.css
+++ b/MathGameProject/styles.css
@@ -1,11 +1,11 @@
 :root {
-  --bg: #0c0d17;
-  --card: #15172b;
-  --accent: #ff7b54;
-  --accent-2: #1db954;
-  --text: #f4f6fb;
-  --muted: #b6bdd6;
-  --shadow: rgba(12, 13, 23, 0.45);
+  --bg: #f6f8fb;
+  --card: #ffffff;
+  --accent: #2c6fb7;
+  --accent-2: #4c9d5a;
+  --text: #1b1b1d;
+  --muted: #5f6572;
+  --shadow: rgba(16, 38, 74, 0.1);
   --font: 'Barlow', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
@@ -16,63 +16,30 @@
 body {
   margin: 0;
   font-family: var(--font);
-  background: radial-gradient(circle at top, #16213f, #0c0d17 58%);
+  background: var(--bg);
   color: var(--text);
   min-height: 100vh;
+  line-height: 1.6;
 }
 
 .hero {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-  padding: 3rem clamp(2rem, 5vw, 6rem) 2rem;
-  gap: 2rem;
+  padding: clamp(2rem, 5vw, 4rem) clamp(1.5rem, 6vw, 5rem) 1.5rem;
+  text-align: center;
 }
 
-.hero__text h1 {
-  margin: 0 0 0.6rem;
-  font-size: clamp(2.5rem, 6vw, 3.8rem);
+.hero h1 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(2rem, 6vw, 3.2rem);
 }
 
 .tagline {
-  font-size: 1.1rem;
-  margin-bottom: 0.4rem;
-}
-
-.subtagline {
-  max-width: 50ch;
+  margin: 0 auto;
   color: var(--muted);
-  line-height: 1.5;
-}
-
-.hero__badge {
-  background: linear-gradient(135deg, var(--accent), #ffa56c);
-  padding: 1.2rem 1.8rem;
-  border-radius: 1rem;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 0.4rem;
-  box-shadow: 0 20px 40px rgba(255, 123, 84, 0.25);
-  min-width: 180px;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  font-weight: 700;
-}
-
-.badge__label {
-  font-size: 0.75rem;
-  opacity: 0.8;
-}
-
-.badge__value {
-  font-size: 1rem;
+  max-width: 50ch;
 }
 
 main {
-  padding: 0 clamp(1.5rem, 5vw, 5rem) 4rem;
+  padding: 0 clamp(1.5rem, 5vw, 4rem) 3rem;
   display: flex;
   flex-direction: column;
   gap: 2.5rem;
@@ -82,10 +49,8 @@ main {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 1rem;
-  background: rgba(21, 23, 43, 0.85);
-  padding: 1.5rem;
-  border-radius: 1.4rem;
-  box-shadow: 0 16px 40px var(--shadow);
+  background: transparent;
+  padding: 0 clamp(0.5rem, 3vw, 1rem);
 }
 
 .control-group {
@@ -100,50 +65,47 @@ label {
 }
 
 select {
-  background: var(--card);
+  background: #ffffff;
   color: var(--text);
-  border: 1px solid rgba(255, 255, 255, 0.15);
-  border-radius: 0.8rem;
-  padding: 0.65rem 0.75rem;
+  border: 1px solid rgba(16, 38, 74, 0.2);
+  border-radius: 0.6rem;
+  padding: 0.6rem 0.75rem;
   font-size: 1rem;
   appearance: none;
   outline: none;
-  transition: border 0.2s ease, transform 0.2s ease;
+  transition: border 0.2s ease;
 }
 
 select:focus {
   border-color: var(--accent);
-  transform: translateY(-1px);
 }
 
 .primary {
-  background: linear-gradient(135deg, var(--accent), #ff9671);
-  color: #0c0d17;
-  font-weight: 700;
+  background: var(--accent);
+  color: #ffffff;
+  font-weight: 600;
   border: none;
-  border-radius: 0.9rem;
-  padding: 0.9rem 1.2rem;
+  border-radius: 0.6rem;
+  padding: 0.8rem 1.2rem;
   cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-  box-shadow: 0 18px 35px rgba(255, 150, 113, 0.25);
+  transition: background 0.2s ease;
 }
 
 .primary:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 22px 40px rgba(255, 150, 113, 0.3);
+  background: #215a96;
 }
 
 .output {
   display: grid;
-  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
-  gap: 1.5rem;
+  grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+  gap: 1rem;
 }
 
 .card {
-  background: rgba(21, 23, 43, 0.95);
-  border-radius: 1.5rem;
-  padding: 1.8rem;
-  box-shadow: 0 22px 45px var(--shadow);
+  background: var(--card);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  box-shadow: 0 20px 40px var(--shadow);
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -158,7 +120,7 @@ select:focus {
 
 .card__header h2 {
   margin: 0;
-  font-size: 1.8rem;
+  font-size: 1.6rem;
 }
 
 .card__context {
@@ -168,7 +130,7 @@ select:focus {
 
 .card__prompt {
   line-height: 1.6;
-  font-size: 1.1rem;
+  font-size: 1.05rem;
 }
 
 .standards {
@@ -179,12 +141,12 @@ select:focus {
 }
 
 .standard-tag {
-  background: rgba(29, 185, 84, 0.15);
-  color: #6af5a7;
-  padding: 0.45rem 0.65rem;
+  background: rgba(76, 157, 90, 0.15);
+  color: var(--accent-2);
+  padding: 0.35rem 0.6rem;
   border-radius: 999px;
   font-weight: 600;
-  font-size: 0.85rem;
+  font-size: 0.8rem;
 }
 
 .card__footer {
@@ -194,9 +156,9 @@ select:focus {
 
 .solution,
 .extension {
-  background: rgba(12, 13, 23, 0.65);
-  border-radius: 1rem;
-  padding: 1.2rem;
+  background: #f1f4f8;
+  border-radius: 0.9rem;
+  padding: 1rem;
   line-height: 1.5;
 }
 
@@ -204,14 +166,7 @@ select:focus {
 .extension h3 {
   margin-top: 0;
   margin-bottom: 0.6rem;
-  font-size: 1.1rem;
-}
-
-.research ul {
-  padding-left: 1.2rem;
-  margin: 0;
-  display: grid;
-  gap: 0.5rem;
+  font-size: 1.05rem;
 }
 
 .research .small {
@@ -220,27 +175,32 @@ select:focus {
 }
 
 .standards-panel {
-  background: rgba(12, 13, 23, 0.75);
-  border-radius: 1.5rem;
-  padding: 1.8rem;
+  background: var(--card);
+  border-radius: 1rem;
+  padding: 1.5rem;
   box-shadow: 0 20px 40px var(--shadow);
 }
 
 .standard-list {
   display: grid;
   gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   margin-top: 1.5rem;
 }
 
 .standard-pill {
-  background: rgba(21, 23, 43, 0.9);
+  background: #f8faff;
   border-left: 4px solid var(--accent-2);
   padding: 1rem 1.2rem;
-  border-radius: 1rem;
+  border-radius: 0.9rem;
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
+}
+
+.standard-strand {
+  font-weight: 600;
+  color: var(--accent);
 }
 
 .standard-pill h4 {
@@ -257,7 +217,7 @@ select:focus {
 
 .footer {
   text-align: center;
-  padding: 2rem 1rem 3rem;
+  padding: 1.5rem 1rem 3rem;
   color: var(--muted);
   font-size: 0.95rem;
 }
@@ -265,15 +225,6 @@ select:focus {
 @media (max-width: 960px) {
   .output {
     grid-template-columns: 1fr;
-  }
-
-  .hero {
-    justify-content: center;
-    text-align: center;
-  }
-
-  .hero__badge {
-    order: -1;
   }
 }
 


### PR DESCRIPTION
## Summary
- streamline the landing layout into a minimal teacher-only workflow with lighter styling
- refresh generator copy to be simple to read while keeping Andrew's comic vocabulary and softer film references
- remove audience toggles and update scripting to deliver teacher prompts, solutions, and extensions only

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68e6d8a69e248324851b7c8b5095c372