### PR TITLE
Add leveled Andrew-centric math prompts with difficulty filter

### DIFF
--- a/MathGameProject/app.js
+++ b/MathGameProject/app.js
@@ -49,109 +49,265 @@ const roundTo = (value, decimals = 2) => {
 };
 
 const toCurrency = value => `$${roundTo(value, 2).toFixed(2)}`;
-
+const toPercent = (value, decimals = 0) => `${roundTo(value * 100, decimals)}%`;
 const choose = array => array[Math.floor(Math.random() * array.length)];
-
-const randomInt = (min, max) => Math.floor(Math.random() * (max - min + 1)) + min;
-
-const ensureNotMultiple = (min, max, forbidden) => {
-  let value = randomInt(min, max);
-  while (forbidden.some(num => value % num === 0)) {
-    value = randomInt(min, max);
-  }
-  return value;
-};
-
 const formatList = items => items.map(item => `<li>${item}</li>`).join('');
 
 const generatorLibrary = [
   {
-    id: 'pull-list-discount',
-    title: 'Pull-Box Discount Check',
-    context: 'comics',
+    id: 'crew-shift-warmup',
+    title: 'Crew Text: Quick Cover',
+    context: 'film',
     skill: 'percents',
-    standards: ['CCSS.MATH.CONTENT.7.RP.A.3', 'CCSS.MATH.CONTENT.7.EE.B.3'],
-    generate: () => {
-      const subtotal = choose([48, 56, 64, 72, 84]);
-      const discountRate = 0.2;
-      const taxRate = 0.085;
-      const discounted = roundTo(subtotal * (1 - discountRate));
-      const taxAmount = roundTo(discounted * taxRate);
-      const total = roundTo(discounted + taxAmount);
-
-      return {
-        title: 'Pull-Box Discount Check',
-        contextLine: 'Comic shop math • Discount plus sales tax',
-        prompt: `Read aloud: "Andrew's pull list at Brightstar Comics costs ${toCurrency(subtotal)} before discounts. The shop takes 20% off for his pull box and then adds 8.5% sales tax. What should the final receipt total be?"`,
-        solutionSteps: [
-          `Discount: ${toCurrency(subtotal)} × 0.20 = ${toCurrency(roundTo(subtotal * discountRate))}.`,
-          `Sale price: ${toCurrency(subtotal)} - discount = ${toCurrency(discounted)}.`,
-          `Tax: ${toCurrency(discounted)} × 0.085 = ${toCurrency(taxAmount)}.`,
-          `Total: ${toCurrency(discounted)} + ${toCurrency(taxAmount)} = ${toCurrency(total)}.`
-        ],
-        finalAnswer: `${toCurrency(total)} due at checkout.`,
-        whyItMatters: 'Teachers can connect percent decrease and increase in one tidy comic book scenario.',
-        extension: 'Change the tax rate to your city or adjust the discount to 15% and compare totals.'
-      };
-    }
-  },
-  {
-    id: 'variant-split',
-    title: 'Variant Team-Up Split',
-    context: 'comics',
-    skill: 'percents',
+    difficulty: 'easy',
     standards: ['CCSS.MATH.CONTENT.7.RP.A.3'],
     generate: () => {
-      const spend = choose([28, 36, 44, 52, 60]);
-      const paybackRate = 0.25;
-      const payback = roundTo(spend * paybackRate);
-      const netCost = roundTo(spend - payback);
+      const weekendHours = choose([10, 12, 15]);
+      const coverageRate = choose([0.1, 0.2]);
+      const coveragePercent = Math.round(coverageRate * 100);
+      const coverageDecimal = roundTo(coverageRate, 2);
+      const coverageHours = roundTo(weekendHours * coverageRate, 1);
 
       return {
-        title: 'Variant Team-Up Split',
-        contextLine: 'Collecting strategy • Sharing a limited cover haul',
-        prompt: `Read aloud: "Andrew and his cousin split a stack of limited variant issues that cost ${toCurrency(spend)}. The cousin covers 25% of the bill later. How much money should Andrew get back, and what is his final cost?"`,
+        title: 'Crew Text: Quick Cover',
+        contextLine: 'Film crew favor • Percent of a weekend shift',
+        prompt: `Read aloud: "A director friend texts Andrew: 'Can you cover ${coveragePercent}% of our ${weekendHours}-hour weekend shoot so our key grip can rest?' How many hours should Andrew block so his yes means something?"`,
         solutionSteps: [
-          `Cousin share: ${toCurrency(spend)} × 0.25 = ${toCurrency(payback)}.`,
-          `Andrew pays after payback: ${toCurrency(spend)} - ${toCurrency(payback)} = ${toCurrency(netCost)}.`
+          `${coveragePercent}% as a decimal is ${coverageDecimal}.`,
+          `${coveragePercent}% of ${weekendHours} hours = ${weekendHours} × ${coverageDecimal} = ${coverageHours} hours.`
         ],
-        finalAnswer: `Andrew gets ${toCurrency(payback)} back and keeps ${toCurrency(netCost)} as his cost.`,
-        whyItMatters: 'Shows percent of a total and reinforces how collectors plan shared buys.',
-        extension: 'Have students model the net cost with an equation such as c = 0.75s and plug in a new stack price.'
+        finalAnswer: `Andrew should reserve ${coverageHours} hours to cover ${coveragePercent}% of the shoot.`,
+        whyItMatters: 'Andrew interprets a percent request from film text threads before committing his time.',
+        extension: 'Ask what happens if the text had said 15% instead and compare the new coverage hours.'
       };
     }
   },
   {
-    id: 'graphic-binders',
-    title: 'Trade Binder Count',
+    id: 'crew-shift-practice',
+    title: 'Crew Call: Percent Plus Editing Time',
+    context: 'film',
+    skill: 'percents',
+    difficulty: 'medium',
+    standards: ['CCSS.MATH.CONTENT.7.RP.A.3'],
+    generate: () => {
+      const weekendHours = choose([18, 20, 22]);
+      const coverageRate = choose([0.25, 0.3]);
+      const coveragePercent = roundTo(coverageRate * 100, 0);
+      const coverageDecimal = roundTo(coverageRate, 2);
+      const coverageHours = roundTo(weekendHours * coverageRate, 1);
+      const editingHours = choose([4, 5]);
+      const leftover = roundTo(weekendHours - coverageHours - editingHours, 1);
+
+      return {
+        title: 'Crew Call: Percent Plus Editing Time',
+        contextLine: 'Weekend scheduling • Combining percents with subtraction',
+        prompt: `Read aloud: "Andrew's friend says, 'Could you cover ${coveragePercent}% of our ${weekendHours}-hour weekend shoot? I can swap you out after that.' Andrew already blocked ${editingHours} hours to edit a behind-the-scenes reel. After he helps, how many weekend hours remain unscheduled?"`,
+        solutionSteps: [
+          `${coveragePercent}% as a decimal is ${coverageDecimal}.`,
+          `Coverage time = ${weekendHours} × ${coverageDecimal} = ${coverageHours} hours.`,
+          `Remaining hours = ${weekendHours} - ${coverageHours} - ${editingHours} = ${leftover} hours.`
+        ],
+        finalAnswer: `Andrew covers ${coverageHours} hours and still has ${leftover} hours open for the rest of the weekend.`,
+        whyItMatters: 'He has to translate percent requests into a real schedule before he replies to crew texts.',
+        extension: 'Have students change the editing block to 6 hours and see if Andrew still has free time.'
+      };
+    }
+  },
+  {
+    id: 'crew-shift-challenge',
+    title: 'Crew Swap: Percent with Rest Check',
+    context: 'film',
+    skill: 'percents',
+    difficulty: 'hard',
+    standards: ['CCSS.MATH.CONTENT.7.RP.A.3'],
+    generate: () => {
+      const scenarios = [
+        { weekendHours: 24, coverageRate: 0.35, editingHours: 5, commuteHours: 3 },
+        { weekendHours: 26, coverageRate: 0.35, editingHours: 5, commuteHours: 4 },
+        { weekendHours: 24, coverageRate: 0.35, editingHours: 4, commuteHours: 4 },
+        { weekendHours: 26, coverageRate: 0.4, editingHours: 4, commuteHours: 4 }
+      ];
+      const restGoal = 6;
+      const scenario = choose(scenarios);
+      const { weekendHours, coverageRate, editingHours, commuteHours } = scenario;
+      const coveragePercent = roundTo(coverageRate * 100, 0);
+      const coverageDecimal = roundTo(coverageRate, 2);
+      const coverageHours = roundTo(weekendHours * coverageRate, 1);
+      const scheduled = roundTo(coverageHours + editingHours + commuteHours, 1);
+      const leftover = roundTo(weekendHours - scheduled, 1);
+      const meetsRest = leftover >= restGoal;
+
+      return {
+        title: 'Crew Swap: Percent with Rest Check',
+        contextLine: 'Weekend logistics • Percent work time plus constraints',
+        prompt: `Read aloud: "Andrew is told, 'Cover ${coveragePercent}% of our ${weekendHours}-hour weekend shoot and we'll pay for rides.' He also promised ${editingHours} hours for script polish and expects commuting to eat ${commuteHours} hours total. He wants at least ${restGoal} hours left for rest. After scheduling everything, does he meet that goal?"`,
+        solutionSteps: [
+          `Crew coverage = ${weekendHours} × ${coverageDecimal} = ${coverageHours} hours.`,
+          `Total scheduled = ${coverageHours} + ${editingHours} + ${commuteHours} = ${scheduled} hours.`,
+          `Remaining = ${weekendHours} - ${scheduled} = ${leftover} hours, compared with the ${restGoal}-hour rest goal.`
+        ],
+        finalAnswer: `Andrew blocks ${coverageHours} crew hours and has ${leftover} hours free, so he ${meetsRest ? 'meets' : 'misses'} the ${restGoal}-hour rest goal.`,
+        whyItMatters: "Percent work promises only matter if they fit with Andrew's commute and rest plan.",
+        extension: 'Adjust the commute time by an hour either way and discuss how it changes the decision.'
+      };
+    }
+  },
+  {
+    id: 'binder-warmup',
+    title: 'Binder Prep Count',
     context: 'comics',
     skill: 'numbers',
+    difficulty: 'easy',
     standards: ['CCSS.MATH.CONTENT.7.NS.A.3'],
     generate: () => {
-      const issues = ensureNotMultiple(20, 38, [6]);
-      const perVolume = 6;
-      const fullVolumes = Math.floor(issues / perVolume);
-      const leftovers = issues % perVolume;
+      const issues = choose([18, 22, 27, 31, 34]);
+      const perBinder = 6;
+      const fullBinders = Math.floor(issues / perBinder);
+      const looseIssues = issues % perBinder;
 
       return {
-        title: 'Trade Binder Count',
-        contextLine: 'Collection planning • Turning single issues into trades',
-        prompt: `Read aloud: "A trade binder holds 6 single issues. Andrew has ${issues} issues ready to archive. How many full trades can he build, and how many single issues will still be loose?"`,
+        title: 'Binder Prep Count',
+        contextLine: 'Collection care • Grouping comics for storage',
+        prompt: `Read aloud: "Andrew is packing story arcs into binders that hold ${perBinder} issues each. If he has ${issues} single issues ready, how many full binders can he set up, and how many issues still need a backing board?"`,
         solutionSteps: [
-          `${issues} ÷ 6 = ${fullVolumes} remainder ${leftovers}.`,
-          `${fullVolumes} full trades with ${leftovers} single issues left over.`
+          `${issues} ÷ ${perBinder} = ${fullBinders} remainder ${looseIssues}.`,
+          `${fullBinders} full binders with ${looseIssues} loose issues left to protect.`
         ],
-        finalAnswer: `${fullVolumes} complete trades and ${leftovers} singles to store separately.`,
-        whyItMatters: 'Interpreting the remainder helps Andrew plan the next binder purchase.',
-        extension: 'Ask students to plan for one more binder and decide how many more issues are needed to fill it.'
+        finalAnswer: `Andrew can prep ${fullBinders} full binders and will still have ${looseIssues} single issues to bag separately.`,
+        whyItMatters: 'He has to interpret the remainder to keep his favorite arcs safe for Artist Alley.',
+        extension: 'Ask how many more issues Andrew needs to fill one more binder completely.'
       };
     }
   },
   {
-    id: 'con-budget',
-    title: 'Convention Budget Board',
+    id: 'color-sprint-practice',
+    title: 'Coloring Sprint Daily Goal',
+    context: 'comics',
+    skill: 'numbers',
+    difficulty: 'medium',
+    standards: ['CCSS.MATH.CONTENT.7.RP.A.3'],
+    generate: () => {
+      const totalPages = choose([48, 60, 72]);
+      const days = choose([12, 15]);
+      const pagesPerDayTogether = roundTo(totalPages / days, 2);
+      const perArtist = roundTo(pagesPerDayTogether / 2, 2);
+
+      return {
+        title: 'Coloring Sprint Daily Goal',
+        contextLine: 'Production schedule • Splitting a page quota',
+        prompt: `Read aloud: "Andrew and a collaborator promised to color a ${totalPages}-page indie comic in ${days} days, dividing the work evenly each day. How many pages should they finish together per day, and how many pages is that for Andrew himself?"`,
+        solutionSteps: [
+          `Daily team quota = ${totalPages} ÷ ${days} = ${pagesPerDayTogether} pages.`,
+          `Andrew's share = ${pagesPerDayTogether} ÷ 2 = ${perArtist} pages per day.`
+        ],
+        finalAnswer: `The team must color ${pagesPerDayTogether} pages per day, so Andrew handles ${perArtist} pages daily.`,
+        whyItMatters: 'Andrew needs the per-day breakdown before promising a delivery date to the creator.',
+        extension: 'Change the deadline by two days and find the new per-person pace.'
+      };
+    }
+  },
+  {
+    id: 'mystery-pack-challenge',
+    title: 'Mystery Pack Assembly Plan',
+    context: 'comics',
+    skill: 'numbers',
+    difficulty: 'hard',
+    standards: ['CCSS.MATH.CONTENT.7.NS.A.3'],
+    generate: () => {
+      const packPlans = [
+        { heroPrints: 36, villainPrints: 26 },
+        { heroPrints: 42, villainPrints: 30 },
+        { heroPrints: 48, villainPrints: 28 }
+      ];
+      const plan = choose(packPlans);
+      const heroPerPack = 3;
+      const villainPerPack = 2;
+      const packsFromHero = Math.floor(plan.heroPrints / heroPerPack);
+      const packsFromVillain = Math.floor(plan.villainPrints / villainPerPack);
+      const fullPacks = Math.min(packsFromHero, packsFromVillain);
+      const heroLeft = plan.heroPrints - fullPacks * heroPerPack;
+      const villainLeft = plan.villainPrints - fullPacks * villainPerPack;
+
+      return {
+        title: 'Mystery Pack Assembly Plan',
+        contextLine: 'Convention prep • Using ratios to build bundles',
+        prompt: `Read aloud: "Andrew is stuffing mystery packs with 3 hero prints and 2 villain prints each. One printer delivery gives him ${plan.heroPrints} hero prints and ${plan.villainPrints} villain prints. How many full packs can he promise the table, and what prints stay loose?"`,
+        solutionSteps: [
+          `Hero prints allow ${plan.heroPrints} ÷ ${heroPerPack} = ${packsFromHero} packs.`,
+          `Villain prints allow ${plan.villainPrints} ÷ ${villainPerPack} = ${packsFromVillain} packs.`,
+          `Full packs = min(${packsFromHero}, ${packsFromVillain}) = ${fullPacks}.`,
+          `Leftovers: ${plan.heroPrints} - (${fullPacks} × ${heroPerPack}) = ${heroLeft} hero prints; ${plan.villainPrints} - (${fullPacks} × ${villainPerPack}) = ${villainLeft} villain prints.`
+        ],
+        finalAnswer: `Andrew can seal ${fullPacks} full mystery packs, leaving ${heroLeft} hero prints and ${villainLeft} villain prints loose for display.`,
+        whyItMatters: 'He has to use ratio reasoning to keep the packs balanced before the doors open.',
+        extension: 'Ask how many more villain prints he should order to use every hero print.'
+      };
+    }
+  },
+  {
+    id: 'long-box-warmup',
+    title: 'Long Box Price Check',
     context: 'comics',
     skill: 'equations',
+    difficulty: 'easy',
+    standards: ['CCSS.MATH.CONTENT.7.EE.B.3', 'CCSS.MATH.CONTENT.7.EE.B.4'],
+    generate: () => {
+      const sleeveCost = choose([7.5, 8.5, 9]);
+      const totalSpend = choose([46, 52, 58]);
+      const subtotal = roundTo(totalSpend - sleeveCost, 2);
+      const boxPrice = roundTo(subtotal / 2, 2);
+
+      return {
+        title: 'Long Box Price Check',
+        contextLine: 'Budgeting • Solving a one-step equation',
+        prompt: `Read aloud: "Andrew is double-checking a quote: two identical long boxes plus ${toCurrency(sleeveCost)} of archival sleeves total ${toCurrency(totalSpend)}. What price per long box should he text back before he agrees?"`,
+        solutionSteps: [
+          `Let x be the price of one long box.`,
+          `Equation: 2x + ${toCurrency(sleeveCost)} = ${toCurrency(totalSpend)}.`,
+          `Subtract sleeves: 2x = ${toCurrency(subtotal)}.`,
+          `x = ${toCurrency(subtotal)} ÷ 2 = ${toCurrency(boxPrice)}.`
+        ],
+        finalAnswer: `Each long box should cost ${toCurrency(boxPrice)} for the quote to make sense.`,
+        whyItMatters: 'Andrew solves a simple equation to be sure the storage deal is fair.',
+        extension: 'Swap in three boxes instead and solve the new equation together.'
+      };
+    }
+  },
+  {
+    id: 'runtime-practice',
+    title: 'Runtime Equation Pitch',
+    context: 'film',
+    skill: 'equations',
+    difficulty: 'medium',
+    standards: ['CCSS.MATH.CONTENT.7.EE.B.4'],
+    generate: () => {
+      const runtimeSeconds = choose([360, 390]);
+      const specialSceneLength = choose([48, 54]);
+      const baseSceneLength = choose([30, 36]);
+      const regularScenes = Math.floor((runtimeSeconds - specialSceneLength) / baseSceneLength);
+
+      return {
+        title: 'Runtime Equation Pitch',
+        contextLine: 'Episode planning • Using an equation to hit a target length',
+        prompt: `Read aloud: "Andrew must prove to his faculty advisor that his short episode will land at ${runtimeSeconds / 60} minutes (${runtimeSeconds} seconds). One finale sequence lasts ${specialSceneLength} seconds, and every other scene template is ${baseSceneLength} seconds. Set up and solve an equation to find how many regular scenes he can script."`,
+        solutionSteps: [
+          `Let x = number of regular scenes.`,
+          `Equation: ${baseSceneLength}x + ${specialSceneLength} = ${runtimeSeconds}.`,
+          `${baseSceneLength}x = ${runtimeSeconds - specialSceneLength}.`,
+          `x = ${runtimeSeconds - specialSceneLength} ÷ ${baseSceneLength} = ${regularScenes}.`
+        ],
+        finalAnswer: `Andrew can script ${regularScenes} regular scenes plus the finale to hit the runtime target.`,
+        whyItMatters: 'He needs to defend his scene count before the advisor locks the schedule.',
+        extension: 'Add a 12-second teaser and resolve the new equation with the class.'
+      };
+    }
+  },
+  {
+    id: 'budget-challenge',
+    title: 'Signing Line Budget Decisions',
+    context: 'comics',
+    skill: 'equations',
+    difficulty: 'hard',
     standards: ['CCSS.MATH.CONTENT.7.EE.B.3'],
     generate: () => {
       const budget = 75;
@@ -193,193 +349,122 @@ const generatorLibrary = [
       const comboList = sortedCombos.map(
         combo => `${combo.pair}: ${toCurrency(combo.total)} (leftover ${toCurrency(combo.leftover)})`
       );
+      const bestCombo = sortedCombos[0];
+      const bestTwoItemMessage = bestCombo
+        ? `Best two-item pick: ${bestCombo.pair} leaves ${toCurrency(bestCombo.leftover)}.`
+        : 'No two-item combo fits the budget.';
+      const threeItemMessage = canBuyThree
+        ? `At least one three-item bundle fits because the cheapest costs ${toCurrency(cheapestThreeTotal)}.`
+        : `No three-item bundle fits because the cheapest costs ${
+            Number.isFinite(cheapestThreeTotal) ? toCurrency(cheapestThreeTotal) : 'N/A'
+          }.`;
 
       return {
-        title: 'Convention Budget Board',
-        contextLine: 'Budget planning • Spending under a set cap',
-        prompt: `Read aloud: "Andrew brings $${budget} to a convention. Prices already include tax. Which two-item bundle stays under budget with the most money left, and is any three-item bundle possible?"`,
+        title: 'Signing Line Budget Decisions',
+        contextLine: 'Convention budgeting • Comparing combinations under a cap',
+        prompt: `Read aloud: "Andrew is texting from the signing line: 'I can only spend $${budget} today. Which two-item combo keeps me under budget with the most cash left, and is there any three-item combo that still works?' Help him respond with confidence."`,
         solutionSteps: [
-          `Cheapest three-item bundle costs ${Number.isFinite(cheapestThreeTotal) ? toCurrency(cheapestThreeTotal) : 'N/A'} ⇒ ${
-            canBuyThree ? 'within budget' : 'over budget'
-          }.`,
+          threeItemMessage,
           comboList.length ? 'Two-item bundles within budget:' : 'No two-item bundle fits the budget.',
           ...comboList
         ],
-        finalAnswer: `${
-          canBuyThree ? 'A three-item combo fits.' : 'No three-item combo fits the cap.'
-        } Best two-item choice leaves ${toCurrency(sortedCombos[0]?.leftover ?? 0)} remaining.`,
-        whyItMatters: 'Teachers can model inequalities and reasoning about combinations without heavy text.',
-        extension: 'Invite students to suggest a new item and test how it changes the best bundle.'
+        finalAnswer: `${threeItemMessage} ${bestTwoItemMessage}`,
+        whyItMatters: 'Andrew weighs combinations against his cash before promising a purchase.',
+        extension: 'Add a new merch item or change the budget and recompute the best bundle.'
       };
     }
   },
   {
-    id: 'storyboard-progress',
-    title: 'Storyboard Progress Check',
-    context: 'film',
-    skill: 'percents',
-    standards: ['CCSS.MATH.CONTENT.7.RP.A.3'],
-    generate: () => {
-      const totalShots = choose([48, 52, 60]);
-      const completed = choose([18, 20, 24]);
-      const percentComplete = roundTo((completed / totalShots) * 100, 1);
-      const shotsLeft = totalShots - completed;
-
-      return {
-        title: 'Storyboard Progress Check',
-        contextLine: 'Film club planning • Tracking percent complete',
-        prompt: `Read aloud: "The film club mapped ${completed} of ${totalShots} planned shots for their mini-movie. What percent is complete, and how many shots remain?"`,
-        solutionSteps: [
-          `Percent complete = (${completed} ÷ ${totalShots}) × 100 = ${percentComplete}%.`,
-          `Shots left = ${totalShots} - ${completed} = ${shotsLeft}.`
-        ],
-        finalAnswer: `${percentComplete}% done with ${shotsLeft} shots still to storyboard.`,
-        whyItMatters: 'Connects percent progress to a school film project Andrew knows from AV club.',
-        extension: 'Ask how many days it will take if the team can finish 6 shots per work session.'
-      };
-    }
-  },
-  {
-    id: 'lighting-share',
-    title: 'Lighting Kit Cost Share',
-    context: 'film',
-    skill: 'percents',
-    standards: ['CCSS.MATH.CONTENT.7.RP.A.3'],
-    generate: () => {
-      const weekendRate = 420;
-      const ratio = [2, 1, 1];
-      const totalParts = ratio.reduce((a, b) => a + b, 0);
-      const partCost = roundTo(weekendRate / totalParts);
-      const andrewShare = roundTo(partCost * ratio[0]);
-      const othersShare = roundTo(weekendRate - andrewShare);
-
-      return {
-        title: 'Lighting Kit Cost Share',
-        contextLine: 'Production budgeting • Splitting rental fees',
-        prompt: `Read aloud: "Three film club leads split a $${weekendRate} lighting rental in a 2:1:1 ratio because Andrew booked extra shooting time. How much does Andrew pay, and how much do the others cover together?"`,
-        solutionSteps: [
-          `Total parts = 2 + 1 + 1 = ${totalParts}.`,
-          `Each part costs ${toCurrency(partCost)}.`,
-          `Andrew pays 2 parts = ${toCurrency(andrewShare)}; friends cover the remaining ${toCurrency(othersShare)}.`
-        ],
-        finalAnswer: `Andrew pays ${toCurrency(andrewShare)}; the team covers ${toCurrency(othersShare)} together.`,
-        whyItMatters: 'Simple ratio split mirrors how clubs share gear rentals.',
-        extension: 'Change the ratio to 3:1:1 if Andrew adds another night and compare the cost shift.'
-      };
-    }
-  },
-  {
-    id: 'scene-equation',
-    title: 'Scene Count Equation',
-    context: 'film',
-    skill: 'equations',
-    standards: ['CCSS.MATH.CONTENT.7.EE.B.4'],
-    generate: () => {
-      const runtimeSeconds = choose([360, 390]);
-      const specialSceneLength = choose([48, 54]);
-      const baseSceneLength = choose([30, 36]);
-      const regularScenes = Math.floor((runtimeSeconds - specialSceneLength) / baseSceneLength);
-
-      return {
-        title: 'Scene Count Equation',
-        contextLine: 'Editing math • Building a clean runtime',
-        prompt: `Read aloud: "A short film must run ${runtimeSeconds / 60} minutes (${runtimeSeconds} seconds). One hero team-up finale lasts ${specialSceneLength} seconds. All other scenes are ${baseSceneLength} seconds each. Set up and solve an equation to find how many regular scenes fit."`,
-        solutionSteps: [
-          `Let x = regular scenes.`,
-          `Equation: ${baseSceneLength}x + ${specialSceneLength} = ${runtimeSeconds}.`,
-          `${baseSceneLength}x = ${runtimeSeconds - specialSceneLength}.`,
-          `x = ${runtimeSeconds - specialSceneLength} ÷ ${baseSceneLength} = ${regularScenes}.`
-        ],
-        finalAnswer: `${regularScenes} regular scenes plus the finale hit the runtime target.`,
-        whyItMatters: 'Gives context for solving one-step equations with a known total.',
-        extension: 'Ask what happens if one more 12-second transition is added to the plan.'
-      };
-    }
-  },
-  {
-    id: 'retake-data',
-    title: 'Reshoot Tracker Stats',
+    id: 'retake-warmup',
+    title: 'Reshoot Log Average',
     context: 'film',
     skill: 'stats',
+    difficulty: 'easy',
     standards: ['CCSS.MATH.CONTENT.7.SP.B.4'],
     generate: () => {
-      const retakes = choose([
-        [2, 4, 3, 5, 3],
-        [1, 5, 4, 3, 2],
-        [2, 3, 4, 6, 3]
-      ]);
-      const labels = ['Scene 1', 'Scene 2', 'Scene 3', 'Scene 4', 'Scene 5'];
+      const retakesSets = [
+        [1, 2, 2, 3],
+        [2, 3, 2, 4],
+        [1, 3, 3, 4]
+      ];
+      const retakes = choose(retakesSets);
+      const labels = ['Scene 1', 'Scene 2', 'Scene 3', 'Scene 4'];
       const sum = retakes.reduce((a, b) => a + b, 0);
       const mean = roundTo(sum / retakes.length, 2);
       const mostRetakes = Math.max(...retakes);
       const hardestSceneIndex = retakes.indexOf(mostRetakes);
 
       return {
-        title: 'Reshoot Tracker Stats',
-        contextLine: 'On-set data • Reading the average number of retakes',
-        prompt: `Read aloud: "Retake counts for five scenes came out as ${retakes.join(', ')}. What is the average number of retakes per scene, and which scene needs the most review?"`,
+        title: 'Reshoot Log Average',
+        contextLine: 'Set report • Mean retakes in four scenes',
+        prompt: `Read aloud: "Andrew logged retake counts for four scenes: ${retakes.join(', ')}. What average should he email to the advisor, and which scene needs the most rehearsal time tomorrow?"`,
         solutionSteps: [
-          `Mean = (${retakes.join(' + ')}) ÷ 5 = ${mean}.`,
+          `Mean = (${retakes.join(' + ')}) ÷ 4 = ${mean}.`,
           `Most retakes: ${mostRetakes} on ${labels[hardestSceneIndex]}.`
         ],
-        finalAnswer: `Average of ${mean} retakes; ${labels[hardestSceneIndex]} needs the most support.`,
-        whyItMatters: 'Supports talk about mean and variability with a familiar film-club log.',
-        extension: 'Have students graph the data and suggest how many practice runs to schedule next time.'
+        finalAnswer: `Average of ${mean} retakes; ${labels[hardestSceneIndex]} needs the most help with ${mostRetakes} retakes.`,
+        whyItMatters: 'Andrew summarizes set data so his advisor knows where to focus coaching.',
+        extension: 'Have students graph the retake counts and suggest a rehearsal plan.'
       };
     }
   },
   {
-    id: 'variant-probability',
-    title: 'Mystery Variant Odds',
+    id: 'variant-probability-practice',
+    title: 'Blind-Bag Odds Check',
     context: 'comics',
     skill: 'stats',
+    difficulty: 'medium',
     standards: ['CCSS.MATH.CONTENT.7.SP.C.6'],
     generate: () => {
       const totalBags = 40;
       const glowVariants = choose([6, 8, 10]);
-      const sketchVariants = choose([4, 5, 6]);
+      const sketchVariants = choose([5, 6, 7]);
       const regular = totalBags - glowVariants - sketchVariants;
       const glowProbability = roundTo(glowVariants / totalBags, 2);
       const sketchProbability = roundTo(sketchVariants / totalBags, 2);
 
       return {
-        title: 'Mystery Variant Odds',
-        contextLine: 'Probability • Blind-bag cover reveal',
-        prompt: `Read aloud: "A blind-bag comic box holds 40 issues: ${glowVariants} glow variants, ${sketchVariants} sketch variants, and the rest regular covers. What is the probability of pulling each special cover on one draw?"`,
+        title: 'Blind-Bag Odds Check',
+        contextLine: "Probability • Interpreting a shop keeper's ratios",
+        prompt: `Read aloud: "Andrew promised his cousin they would open ${totalBags} blind-bag comics tonight. The shop owner says there are ${glowVariants} glow variants, ${sketchVariants} sketch variants, and the rest regular covers. What is the probability of pulling each special cover on a single draw so Andrew can set expectations?"`,
         solutionSteps: [
-          `P(glow) = ${glowVariants} ÷ 40 = ${glowProbability}.`,
-          `P(sketch) = ${sketchVariants} ÷ 40 = ${sketchProbability}.`,
-          `Regular covers = ${regular} bags.`
+          `P(glow) = ${glowVariants} ÷ ${totalBags} = ${glowProbability} (${toPercent(glowVariants / totalBags)}).`,
+          `P(sketch) = ${sketchVariants} ÷ ${totalBags} = ${sketchProbability} (${toPercent(sketchVariants / totalBags)}).`,
+          `Regular covers = ${regular} of ${totalBags} bags.`
         ],
-        finalAnswer: `Glow: ${glowProbability}; Sketch: ${sketchProbability}.`,
-        whyItMatters: 'Highlights theoretical probability with terms Andrew hears at the comic shop.',
-        extension: 'Invite students to simulate two draws with counters and compare to the predicted odds.'
+        finalAnswer: `Glow odds: ${glowProbability} (${toPercent(glowVariants / totalBags)}); Sketch odds: ${sketchProbability} (${toPercent(sketchVariants / totalBags)}).`,
+        whyItMatters: 'Andrew explains the probabilities before his cousin trades away a favorite pull.',
+        extension: 'Ask what the probability would be after one glow variant is removed from the box.'
       };
     }
   },
   {
-    id: 'colorist-collab',
-    title: 'Coloring Sprint Ratio',
+    id: 'variant-probability-challenge',
+    title: 'Two-Draw Glow Guarantee',
     context: 'comics',
-    skill: 'numbers',
-    standards: ['CCSS.MATH.CONTENT.7.RP.A.3'],
+    skill: 'stats',
+    difficulty: 'hard',
+    standards: ['CCSS.MATH.CONTENT.7.SP.C.6'],
     generate: () => {
-      const totalPages = choose([48, 60, 72]);
-      const days = choose([12, 15]);
-      const pagesPerDayTogether = roundTo(totalPages / days, 2);
-      const perArtist = roundTo(pagesPerDayTogether / 2, 2);
+      const totalBags = 40;
+      const glowVariants = choose([6, 8, 10]);
+      const sketchVariants = choose([5, 6, 7]);
+      const nonGlow = totalBags - glowVariants;
+      const noGlowProbability = roundTo((nonGlow / totalBags) * ((nonGlow - 1) / (totalBags - 1)), 4);
+      const atLeastOneGlow = roundTo(1 - noGlowProbability, 4);
 
       return {
-        title: 'Coloring Sprint Ratio',
-        contextLine: 'Production schedule • Splitting daily work evenly',
-        prompt: `Read aloud: "Andrew and a friend are coloring a ${totalPages}-page comic in ${days} days. They split the pages evenly each day. How many pages should they finish together per day, and how many pages is that for each artist?"`,
+        title: 'Two-Draw Glow Guarantee',
+        contextLine: 'Probability • Complement strategy with blind bags',
+        prompt: `Read aloud: "Andrew told his cousin, 'If we grab two blind bags without replacement, we should almost guarantee at least one glow cover.' The box holds ${glowVariants} glow variants and ${sketchVariants} sketch variants among ${totalBags} books. What is the probability they end up with at least one glow cover in two pulls?"`,
         solutionSteps: [
-          `Pages per day together = ${totalPages} ÷ ${days} = ${pagesPerDayTogether}.`,
-          `Per artist = ${pagesPerDayTogether} ÷ 2 = ${perArtist}.`
+          `Non-glow covers = ${nonGlow}.`,
+          `P(no glow in two pulls) = (${nonGlow} ÷ ${totalBags}) × (${nonGlow - 1} ÷ ${totalBags - 1}) = ${noGlowProbability}.`,
+          `P(at least one glow) = 1 - ${noGlowProbability} = ${atLeastOneGlow} (${toPercent(atLeastOneGlow, 1)}).`
         ],
-        finalAnswer: `Team goal ${pagesPerDayTogether} pages daily; each artist handles ${perArtist} pages.`,
-        whyItMatters: 'Reinforces equal sharing and rate reasoning using comic art workflow.',
-        extension: 'Ask what happens to the plan if one artist finishes 4 bonus pages on day one.'
+        finalAnswer: `Andrew can quote a ${toPercent(atLeastOneGlow, 1)} chance of seeing at least one glow cover in two pulls.`,
+        whyItMatters: "He interprets probability so he doesn't overpromise rare covers to family.",
+        extension: 'Have students compare the probability if they could choose three bags instead of two.'
       };
     }
   }
@@ -388,6 +473,7 @@ const generatorLibrary = [
 const elements = {
   context: document.getElementById('context'),
   skill: document.getElementById('skill'),
+  difficulty: document.getElementById('difficulty'),
   generate: document.getElementById('generate'),
   problemTitle: document.getElementById('problem-title'),
   problemContext: document.getElementById('problem-context'),
@@ -416,11 +502,13 @@ const renderStandardsReference = () => {
 const renderProblem = () => {
   const contextFilter = elements.context.value;
   const skillFilter = elements.skill.value;
+  const difficultyFilter = elements.difficulty.value;
 
   const filtered = generatorLibrary.filter(generator => {
     const contextMatch = contextFilter === 'all' || generator.context === contextFilter;
     const skillMatch = skillFilter === 'all' || generator.skill === skillFilter;
-    return contextMatch && skillMatch;
+    const difficultyMatch = difficultyFilter === 'all' || generator.difficulty === difficultyFilter;
+    return contextMatch && skillMatch && difficultyMatch;
   });
 
   if (!filtered.length) {
@@ -435,9 +523,15 @@ const renderProblem = () => {
 
   const selection = choose(filtered);
   const problem = selection.generate();
+  const difficultyLabelMap = {
+    easy: 'Level 1 – Warm-Up',
+    medium: 'Level 2 – Practice',
+    hard: 'Level 3 – Challenge'
+  };
+  const difficultyText = difficultyLabelMap[selection.difficulty] || 'Custom Level';
 
   elements.problemTitle.textContent = problem.title;
-  elements.problemContext.textContent = problem.contextLine;
+  elements.problemContext.textContent = `${problem.contextLine} • ${difficultyText}`;
   elements.problemText.textContent = problem.prompt;
   elements.standards.innerHTML = selection.standards
     .map(code => `<span class="standard-tag">${code.replace('CCSS.MATH.CONTENT.', '')}</span>`)
@@ -463,5 +557,6 @@ elements.generate.addEventListener('click', renderProblem);
 
 elements.context.addEventListener('change', renderProblem);
 elements.skill.addEventListener('change', renderProblem);
+elements.difficulty.addEventListener('change', renderProblem);
 
 renderStandardsReference();

--- a/MathGameProject/index.html
+++ b/MathGameProject/index.html
@@ -35,6 +35,15 @@
           <option value="stats">Statistics &amp; Probability (7.SP)</option>
         </select>
       </div>
+      <div class="control-group">
+        <label for="difficulty">Level</label>
+        <select id="difficulty">
+          <option value="all">Any Level</option>
+          <option value="easy">Level 1 – Warm-Up</option>
+          <option value="medium">Level 2 – Practice</option>
+          <option value="hard">Level 3 – Challenge</option>
+        </select>
+      </div>
       <button id="generate" class="primary">Generate Example</button>
     </section>
 


### PR DESCRIPTION
## Summary
- replace the generator catalog with easy, medium, and hard Andrew-focused story problems across every math strand
- wire a new difficulty filter into the generator so teachers can target warm-up, practice, or challenge prompts
- surface level information alongside each scenario for clarity while keeping the standards tags intact

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e6daf1a11883248335afd14d4761f3